### PR TITLE
Improved readibility (using choices instead of enum)

### DIFF
--- a/AutofillAIExternalModule.php
+++ b/AutofillAIExternalModule.php
@@ -214,7 +214,7 @@ class AutofillAIExternalModule extends AbstractExternalModule {
 				if (strlen($field_label) > 0) $prompt =  str_replace('[prompt-label]', $field_label, $prompt);
 				if (strlen($field_enum) > 0) {
 					$field_enum = str_replace("\\n", "\n", $field_enum);
-					$prompt =  str_replace('[prompt-enum]', "\n\ncode,fact\n" . $field_enum . "\n\n", $prompt);
+					$prompt =  str_replace('[prompt-choices]', "\n\ncode,fact\n" . $field_enum . "\n\n", $prompt);
 				}
 				break;
 			case 'checkbox':
@@ -223,7 +223,7 @@ class AutofillAIExternalModule extends AbstractExternalModule {
 				if (strlen($field_label) > 0) $prompt =  str_replace('[prompt-label]', $field_label, $prompt);
 				if (strlen($field_enum) > 0) {
 					$field_enum = str_replace("\\n", "\n", $field_enum);
-					$prompt =  str_replace('[prompt-enum]', "\n\ncode,fact\n" . $field_enum . "\n\n", $prompt);
+					$prompt =  str_replace('[prompt-choices]', "\n\ncode,fact\n" . $field_enum . "\n\n", $prompt);
 				}
 				break;
 			case 'yesno':
@@ -232,7 +232,7 @@ class AutofillAIExternalModule extends AbstractExternalModule {
 				if (strlen($field_label) > 0) $prompt =  str_replace('[prompt-label]', $field_label, $prompt);
 				if (strlen($field_enum) > 0) {
 					$field_enum = str_replace("\\n", "\n", $field_enum);
-					$prompt =  str_replace('[prompt-enum]', "\n\ncode,fact\n" . $field_enum . "\n\n", $prompt);
+					$prompt =  str_replace('[prompt-choices]', "\n\ncode,fact\n" . $field_enum . "\n\n", $prompt);
 				}
 				break;
 			case 'truefalse':
@@ -241,7 +241,7 @@ class AutofillAIExternalModule extends AbstractExternalModule {
 				if (strlen($field_label) > 0) $prompt =  str_replace('[prompt-label]', $field_label, $prompt);
 				if (strlen($field_enum) > 0) {
 					$field_enum = str_replace("\\n", "\n", $field_enum);
-					$prompt =  str_replace('[prompt-enum]', "\n\ncode,fact\n" . $field_enum . "\n\n", $prompt);
+					$prompt =  str_replace('[prompt-choices]', "\n\ncode,fact\n" . $field_enum . "\n\n", $prompt);
 				}
 				break;
 			case 'slider':
@@ -250,7 +250,7 @@ class AutofillAIExternalModule extends AbstractExternalModule {
 				if (strlen($field_label) > 0) $prompt =  str_replace('[prompt-label]', $field_label, $prompt);
 				if (strlen($field_enum) > 0) {
 					$field_enum = str_replace("\\n", "\n", $field_enum);
-					$prompt =  str_replace('[prompt-enum]', "\n\ncode,fact\n" . $field_enum . "\n\n", $prompt);
+					$prompt =  str_replace('[prompt-choices]', "\n\ncode,fact\n" . $field_enum . "\n\n", $prompt);
 				}
 				break;
 			default:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The configuration is done exclusively within the project context. The following 
 - *llm-system-prompt-notes*: Specific LLM system prompt for *notes*
     - could consist only of *[prompt-general]*
 - *llm-system-prompt-radio-dropdown*: Specific LLM system prompt for *radio* or *dropdown*
-    -  effective prompts look like this: *[prompt-general] Response strictly with the codes in the first column of this table and nothing else:\n[prompt-enum]\nOnly codes!*
+    -  effective prompts look like this: *[prompt-general] Response strictly with the codes in the first column of this table and nothing else:\n[prompt-choices]\nOnly codes!*
 - *llm-system-prompt-checkbox*: Specific LLM system prompt for *checkbox*
 - *llm-system-prompt-yesno*: Specific LLM system prompt for *yesno*
 - *llm-system-prompt-truefalse*: Specific LLM system prompt for *truefalse*

--- a/config.json
+++ b/config.json
@@ -130,31 +130,31 @@
       },
       {
          "key": "llm-system-prompt-radio-dropdown",
-         "name": "Specific LLM system prompt for \"radio\" or \"dropdown\". You can pipe [prompt-general], [prompt-label], and [prompt-enum] of the current field into.",
+         "name": "Specific LLM system prompt for \"radio\" or \"dropdown\". You can pipe [prompt-general], [prompt-label], and [prompt-choices] of the current field into.",
          "type": "text",
-         "default": "[prompt-general] Response strictly with the codes in the first column of this table and nothing else:\n[prompt-enum]\nOnly codes!"
+         "default": "[prompt-general] Response strictly with the codes in the first column of this table and nothing else:\n[prompt-choices]\nOnly codes!"
       },
       {
          "key": "llm-system-prompt-checkbox",
-         "name": "Specific LLM system prompt for \"checkbox\". You can pipe [prompt-general], [prompt-label], and [prompt-enum] of the current field into.",
+         "name": "Specific LLM system prompt for \"checkbox\". You can pipe [prompt-general], [prompt-label], and [prompt-choices] of the current field into.",
          "type": "text",
-         "default": "[prompt-general] Response strictly with the codes in the first column of this table and nothing else:\n[prompt-enum]\nOnly codes!"
+         "default": "[prompt-general] Response strictly with the codes in the first column of this table and nothing else:\n[prompt-choices]\nOnly codes!"
       },
       {
          "key": "llm-system-prompt-yesno",
-         "name": "Specific LLM system prompt for \"yesno\". You can pipe [prompt-general], [prompt-label], and [prompt-enum] of the current field into.",
+         "name": "Specific LLM system prompt for \"yesno\". You can pipe [prompt-general], [prompt-label], and [prompt-choices] of the current field into.",
          "type": "text",
-         "default": "[prompt-general] Response strictly with the codes in the first column of this table and nothing else:\n[prompt-enum]\nOnly codes!"
+         "default": "[prompt-general] Response strictly with the codes in the first column of this table and nothing else:\n[prompt-choices]\nOnly codes!"
       },
       {
          "key": "llm-system-prompt-truefalse",
-         "name": "Specific LLM system prompt for \"truefalse\". You can pipe [prompt-general], [prompt-label], and [prompt-enum] of the current field into.",
+         "name": "Specific LLM system prompt for \"truefalse\". You can pipe [prompt-general], [prompt-label], and [prompt-choices] of the current field into.",
          "type": "text",
-         "default": "[prompt-general] Response strictly with the codes in the first column of this table and nothing else:\n[prompt-enum]\nOnly codes!"
+         "default": "[prompt-general] Response strictly with the codes in the first column of this table and nothing else:\n[prompt-choices]\nOnly codes!"
       },
       {
          "key": "llm-system-prompt-slider",
-         "name": "Specific LLM system prompt for \"slider\". You can pipe [prompt-general], [prompt-label], and [prompt-enum] of the current field into.",
+         "name": "Specific LLM system prompt for \"slider\". You can pipe [prompt-general], [prompt-label], and [prompt-choices] of the current field into.",
          "type": "text",
          "default": "[prompt-general] Response with an integer number between 0 and 100. 0 means minimum and 100 maximum."
       }


### PR DESCRIPTION
enum was used as term for choices in radios, checkboxes etc. which could be misleading.