### PR TITLE
Added dependency checking for piping in factory mode

### DIFF
--- a/js/autofill-ai.js
+++ b/js/autofill-ai.js
@@ -297,12 +297,10 @@ async function autoFillFactoryAIPostRequest(data) {
     });
 }
 
-async function autoFillAIFactoryMultiplePostRequests(record_list, field_list, overwrite_flag) {
+async function autoFillAIFactoryMultiplePostRequests(records, fields, overwrite_flag) {
     const maxParallelRequests = 3;
     const promises = [];
 
-	var records = JSON.parse(record_list);
-	var fields = JSON.parse(field_list);
 	var fields_per_record = new Map;
 	records.forEach((record) => {
 		fields_per_record.set(record, fields.length);

--- a/lang/English.ini
+++ b/lang/English.ini
@@ -42,6 +42,7 @@ ui_factory_overwrite_mode = "Overwrite fields"
 ui_factory_all_fields_selected = "All fields"
 ui_factory_all_records_selected = "All records"
 ui_factory_generate_btn = "Generate"
+ui_factory_cyclic_dependencies = "There are cyclic dependencies in piping other fields into prompts:<br>{0}These fields are currently skipped. It can be fixed by modifying the affected field prompts in the @AUTOFILL-AI action tag."
 
 ; Errors
 js_failed_requests = "Batch of requests failed:"


### PR DESCRIPTION
A dependency checking based on Kahn's algorithm was added to bring execution of prompts in the factory mode in the right order. Fields with cyclic dependencies are skipped.